### PR TITLE
JVM buildpack update

### DIFF
--- a/builders/heroku/20/builder.toml
+++ b/builders/heroku/20/builder.toml
@@ -10,7 +10,7 @@ description = "Base builder for Heroku-20 stack, based on ubuntu:20.04 base imag
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:21990393c93927b16f76c303ae007ea7e95502d52b0317ca773d4cd51e7a5682"
+  uri = "docker://docker.io/heroku/buildpack-java@sha256:c6dd500be06a2a1e764c30359c5dd4f4955a98b572ef3095b2f6115cd8a87c99"
 
 [[buildpacks]]
   id = "heroku/scala"
@@ -151,7 +151,7 @@ description = "Base builder for Heroku-20 stack, based on ubuntu:20.04 base imag
 
   [[order.group]]
     id = "heroku/java"
-    version = "0.6.9"
+    version = "0.6.10"
 
   [[order.group]]
     id = "koyeb/custom"
@@ -162,7 +162,7 @@ description = "Base builder for Heroku-20 stack, based on ubuntu:20.04 base imag
 
   [[order.group]]
     id = "heroku/jvm"
-    version = "1.0.9"
+    version = "1.0.10"
 
   [[order.group]]
     id = "heroku/gradle"


### PR DESCRIPTION
# jvm buildpack

[See changelog](https://github.com/heroku/buildpacks-jvm/blob/main/buildpacks/jvm/CHANGELOG.md)

## [1.0.10] 2023/05/10

* Upgrade `libcnb` and `libherokubuildpack` to `0.12.0`. ([#463](https://github.com/heroku/buildpacks-jvm/pull/463))
* The buildpack now implements Buildpack API 0.9 instead of 0.8, and so requires `lifecycle` 0.15.x or newer. ([#463](https://github.com/heroku/buildpacks-jvm/pull/463))