### PR TITLE
Update jvm & Nodejs

### DIFF
--- a/builders/heroku/20/builder.toml
+++ b/builders/heroku/20/builder.toml
@@ -10,7 +10,7 @@ description = "Base builder for Heroku-20 stack, based on ubuntu:20.04 base imag
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "docker://docker.io/heroku/buildpack-java@sha256:43cc23409922c6b3af6886bd810a350e44bec2c2eb52fc3bfd7851e7165f41b8"
+  uri = "docker://docker.io/heroku/buildpack-java@sha256:a5a946975e79d73d0a0f801aa3b8cc4e3de69a092eb588aa69e8c7d2552bc581"
 
 [[buildpacks]]
   id = "heroku/scala"
@@ -151,7 +151,7 @@ description = "Base builder for Heroku-20 stack, based on ubuntu:20.04 base imag
 
   [[order.group]]
     id = "heroku/java"
-    version = "1.1.2"
+    version = "2.0.0"
 
   [[order.group]]
     id = "koyeb/custom"
@@ -162,7 +162,7 @@ description = "Base builder for Heroku-20 stack, based on ubuntu:20.04 base imag
 
   [[order.group]]
     id = "heroku/jvm"
-    version = "1.1.2"
+    version = "2.0.0"
 
   [[order.group]]
     id = "heroku/gradle"

--- a/builders/heroku/20/builder.toml
+++ b/builders/heroku/20/builder.toml
@@ -26,7 +26,7 @@ description = "Base builder for Heroku-20 stack, based on ubuntu:20.04 base imag
 
 [[buildpacks]]
   id = "heroku/procfile"
-  uri = "docker://docker.io/heroku/procfile-cnb:2.0.0"
+  uri = "docker://docker.io/heroku/procfile-cnb@sha256:ea7219d4bb50196b4f292c9aae397b17255c59a243d7408535d2a03a5cd2b040"
 
 [[buildpacks]]
   id = "heroku/python"
@@ -64,7 +64,7 @@ description = "Base builder for Heroku-20 stack, based on ubuntu:20.04 base imag
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "2.0.0"
+    version = "2.0.1"
     optional = true
 
   [[order.group]]
@@ -80,7 +80,7 @@ description = "Base builder for Heroku-20 stack, based on ubuntu:20.04 base imag
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "2.0.0"
+    version = "2.0.1"
     optional = true
 
   [[order.group]]
@@ -96,7 +96,7 @@ description = "Base builder for Heroku-20 stack, based on ubuntu:20.04 base imag
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "2.0.0"
+    version = "2.0.1"
     optional = true
 
   [[order.group]]
@@ -112,7 +112,7 @@ description = "Base builder for Heroku-20 stack, based on ubuntu:20.04 base imag
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "2.0.0"
+    version = "2.0.1"
     optional = true
 
   [[order.group]]
@@ -128,7 +128,7 @@ description = "Base builder for Heroku-20 stack, based on ubuntu:20.04 base imag
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "2.0.0"
+    version = "2.0.1"
     optional = true
 
   [[order.group]]
@@ -170,7 +170,7 @@ description = "Base builder for Heroku-20 stack, based on ubuntu:20.04 base imag
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "2.0.0"
+    version = "2.0.1"
     optional = true
 
   [[order.group]]

--- a/builders/heroku/20/builder.toml
+++ b/builders/heroku/20/builder.toml
@@ -10,7 +10,7 @@ description = "Base builder for Heroku-20 stack, based on ubuntu:20.04 base imag
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "docker://docker.io/heroku/buildpack-java@sha256:a5a946975e79d73d0a0f801aa3b8cc4e3de69a092eb588aa69e8c7d2552bc581"
+  uri = "docker://docker.io/heroku/buildpack-java@sha256:7e4a2bc5f80e6892949117e3ae48ecac0b54760058999c48a5907a56268949fe"
 
 [[buildpacks]]
   id = "heroku/scala"
@@ -42,7 +42,7 @@ description = "Base builder for Heroku-20 stack, based on ubuntu:20.04 base imag
 
 [[buildpacks]]
   id = "heroku/nodejs"
-  uri = "docker://docker.io/heroku/buildpack-nodejs@sha256:e5519335d777a818929aa2050b4a8d0b73e9d31f3593779732631b3cf4c08f34"
+  uri = "docker://docker.io/heroku/buildpack-nodejs@sha256:94a5360759d28b86415a5c8e7f4602591154b97d51573eb3d353d84397c35602"
 
 [[buildpacks]]
   id = "heroku/clojure"
@@ -145,13 +145,13 @@ description = "Base builder for Heroku-20 stack, based on ubuntu:20.04 base imag
 
   [[order.group]]
     id = "heroku/nodejs"
-    version = "1.1.3"
+    version = "1.1.4"
 
 [[order]]
 
   [[order.group]]
     id = "heroku/java"
-    version = "2.0.0"
+    version = "3.0.0"
 
   [[order.group]]
     id = "koyeb/custom"
@@ -162,7 +162,7 @@ description = "Base builder for Heroku-20 stack, based on ubuntu:20.04 base imag
 
   [[order.group]]
     id = "heroku/jvm"
-    version = "2.0.0"
+    version = "3.0.0"
 
   [[order.group]]
     id = "heroku/gradle"

--- a/builders/heroku/20/builder.toml
+++ b/builders/heroku/20/builder.toml
@@ -10,7 +10,7 @@ description = "Base builder for Heroku-20 stack, based on ubuntu:20.04 base imag
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "docker://docker.io/heroku/buildpack-java@sha256:3c888077056f93d3ceb7c8a5b3dede3e2b06bfa169a8e3fc7383374b6773265a"
+  uri = "docker://docker.io/heroku/buildpack-java@sha256:43cc23409922c6b3af6886bd810a350e44bec2c2eb52fc3bfd7851e7165f41b8"
 
 [[buildpacks]]
   id = "heroku/scala"
@@ -42,7 +42,7 @@ description = "Base builder for Heroku-20 stack, based on ubuntu:20.04 base imag
 
 [[buildpacks]]
   id = "heroku/nodejs"
-  uri = "docker://docker.io/heroku/buildpack-nodejs@sha256:e6f38bb7833677c4530c5b06de9cda5da9aac7ead5772b980083e14614346742"
+  uri = "docker://docker.io/heroku/buildpack-nodejs@sha256:e5519335d777a818929aa2050b4a8d0b73e9d31f3593779732631b3cf4c08f34"
 
 [[buildpacks]]
   id = "heroku/clojure"
@@ -145,13 +145,13 @@ description = "Base builder for Heroku-20 stack, based on ubuntu:20.04 base imag
 
   [[order.group]]
     id = "heroku/nodejs"
-    version = "1.1.1"
+    version = "1.1.3"
 
 [[order]]
 
   [[order.group]]
     id = "heroku/java"
-    version = "0.6.11"
+    version = "1.1.2"
 
   [[order.group]]
     id = "koyeb/custom"
@@ -162,7 +162,7 @@ description = "Base builder for Heroku-20 stack, based on ubuntu:20.04 base imag
 
   [[order.group]]
     id = "heroku/jvm"
-    version = "1.0.10"
+    version = "1.1.2"
 
   [[order.group]]
     id = "heroku/gradle"


### PR DESCRIPTION
# Nodejs

- Added Node.js version 16.20.2.
- Added Node.js version 18.17.1.
- Added Node.js version 20.5.1.

# JVM

- Remove support for installing Maven 3.2.5, 3.3.9, 3.5.4 and 3.6.2 via system.properties. These versions of Maven contain security vulnerabilities and should not be used. Users that cannot upgrade to a secure version of Maven can install the Maven Wrapper for the required Maven version to their application (i.e. mvn wrapper:wrapper -Dmaven=3.6.2). (https://github.com/heroku/buildpacks-jvm/pull/556)
Default version for Maven is now 3.9.4. (https://github.com/heroku/buildpacks-jvm/pull/556)